### PR TITLE
Fixed typos and re-formulated text

### DIFF
--- a/_includes/contribute.html
+++ b/_includes/contribute.html
@@ -3,7 +3,7 @@
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">Contribute</h2>
-                    <h3 class="section-subheading text-muted">If you are interested in this project, please feel free to contribute. The RaspInLoop project is hosted at https://github.com/RaspInLoop/RaspInLoop-fmi-plugin , associated to the project you can find some open issues labeled with help wanted or good first issue</h3>
+                    <h3 class="section-subheading text-muted">If you are interested in this project, please feel free to contribute. The RaspInLoop project is hosted at <a href="https://github.com/RaspInLoop/RaspInLoop-fmi-plugin">https://github.com/RaspInLoop/RaspInLoop-fmi-plugin</a>, associated to the project you can find some open issues labeled with <i>help wanted</i> or <i>good first issue<i></i></h3>
                 </div>
             </div>
         </div>

--- a/_includes/flavour.html
+++ b/_includes/flavour.html
@@ -4,7 +4,7 @@
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">Flavour</h2>
-                    <h3 class="section-subheading text-muted">Raspinloop is available in different packages:</h3>
+                    <h3 class="section-subheading text-muted">RaspInLoop is available in different packages:</h3>
                 </div>
             </div>
             <div class="row text-center">
@@ -15,7 +15,7 @@
                         <i class="fa fa-file-code-o fa-stack-1x fa-inverse"></i>
                     </span>
                     <h4 class="service-heading">Raw</h4>
-                    <p class="text-muted">Use library or command line java tools to debug your Pi4j application under simulation </p>
+                    <p class="text-muted">Use library or command line Java tools to debug your Pi4J application under simulation </p>
                   </a>
                 </div>
                 <div class="col-md-4">
@@ -25,7 +25,7 @@
                         <i class="fa fa-cubes fa-stack-1x fa-inverse"></i>
                     </span>
                     <h4 class="service-heading">Eclipse Plugin</h4>
-                    <p class="text-muted">Debug your Pi4j application directly from eclipse while your simulation is running. Hardware configuration is also available from eclipse.</p>
+                    <p class="text-muted">Debug your Pi4J application directly from Eclipse while your simulation is running. Hardware configuration is also available from Eclipse.</p>
                     </a>
                 </div>
                 <div class="col-md-4">
@@ -34,7 +34,7 @@
                         <i class="fa fa-circle fa-stack-2x text-primary"></i>
                         <i class="fa fa-cubes fa-stack-1x fa-inverse"></i>
                     </span>
-                    <h4 class="service-heading">InetlliJ IDEA Plugin</h4>
+                    <h4 class="service-heading">IntelliJ IDEA Plugin</h4>
                     <p class="text-muted">Coming soon...</p>
                   </a>
                 </div>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -42,7 +42,7 @@
         <div class="container">
             <div class="intro-text">
                 <div class="intro-lead-in">Put the Raspberry Pi in the Simulation Loop</div>
-                <div class="intro-heading">RaspinLoop</div>
+                <div class="intro-heading">RaspInLoop</div>
                 <a href="#flavour" class="page-scroll btn btn-xl">Tell Me More</a>
             </div>
         </div>

--- a/_includes/howitworks.html
+++ b/_includes/howitworks.html
@@ -4,7 +4,7 @@
             <div class="row">
                 <div class="col-lg-12 text-center">
                     <h2 class="section-heading">How it Works</h2>
-                    <h3 class="section-subheading text-muted">Co-Simulation using FMI standard is the keystone of Raspinloop.</h3>
+                    <h3 class="section-subheading text-muted">Co-Simulation using FMI standard is the keystone of RaspInloop.</h3>
                 </div>
             </div>
             <div class="row">
@@ -16,11 +16,11 @@
                             </div>
                             <div class="timeline-panel">
                                 <div class="timeline-heading">
-                                    <h4>Pij4 Application</h4>
+                                    <h4>Pi4J Application</h4>
                                     <h4 class="subheading">Code your application</h4>
                                 </div>
                                 <div class="timeline-body">
-                                    <p class="text-muted">Thanks to <a href="http://pi4j.com/">Pi4j project</a>, you have all you need to develop your java application on Raspberry Pi. Including a lot of components like stepper motor, servo, i2c and spi devices,...</p>
+                                    <p class="text-muted">Thanks to the <a href="http://pi4j.com/">Pi4J project</a>, you have all you need to develop your Java application on Raspberry Pi. Including a lot of components like stepper motor, servo, I2C, SPI devices, etc...</p>
                                 </div>
                             </div>
                         </li>
@@ -34,7 +34,7 @@
                                   <h4 class="subheading">Specify the attached components</h4>
                               </div>
                               <div class="timeline-body">
-                                  <p class="text-muted">Usually, some detectors and actuators are attached to your raspberry board. Before running the simulation, you have to setup those components and their parameters.</p>
+                                  <p class="text-muted">Usually, some detectors and actuators are attached to your Raspberry board. Before running the simulation, you have to setup those components and their parameters.</p>
                               </div>
                             </div>
                         </li>
@@ -48,7 +48,7 @@
                                   <h4 class="subheading">Modeling and simulation environment.</h4>
                               </div>
                               <div class="timeline-body">
-                                  <p class="text-muted">Using your prefered modeling and simulation tool, your may describe the "world" connected to your raspberry Pi. This tool will import a "block" linked to modelized external variable (ie:  temperature, force, velocity, acceleration). All tools able to act as "Master FMI 2.0 Co-Simulation" can be used. <a href="http://fmi-standard.org/tools/">see list</a></p>
+                                  <p class="text-muted">Using your preferred modeling and simulation tool, your may describe the "world" connected to your rRaspberry Pi. This tool will import a "block" linked to the modelled external variable (ie:  temperature, force, velocity, acceleration). All tools able to act as "Master FMI 2.0 Co-Simulation" can be used. <a href="http://fmi-standard.org/tools/">See list of compatible tools.</a></p>
                               </div>
                             </div>
                         </li>
@@ -59,10 +59,10 @@
                             <div class="timeline-panel">
                                 <div class="timeline-heading">
                                     <h4>Debugging</h4>
-                                    <h4 class="subheading">Freeze time !</h4>
+                                    <h4 class="subheading">Freeze time!</h4>
                                 </div>
                                 <div class="timeline-body">
-                                    <p class="text-muted">Place your breakpoints, start your application in debug mode and start your simulation. Now your simulation tool act as a clock for the whole system, allowing the debbuger to stop(breakpoint) to have the time for inspecting and understand what happens inside a milliseconds. Moreover, it allows to simulate process long as several days in a few seconds...</p>
+                                    <p class="text-muted">Place your breakpoints, start your application in debug mode and start your simulation. Now your simulation tool acts as a clock for the whole system, allowing the debugger to stop at breakpoints, allowing for inspection and understanding of what happens at millisecond levels! Moreover, it allows for simulation of day-long processes in just a few seconds...</p>
                                 </div>
                             </div>
                         </li>


### PR DESCRIPTION
Fixed spelling and re-formulated a few sentences for clarity. Fixed correct styling of brand names according to either manufacturer or standardization. See details below.

### Fixed spelling
* `prefered` -> `preferred`
* `list of tools` -> `See list of compatible tools.`
...see full diff for all changes.

### Fixed correct styling of brand names
* Changed `Pi4j` -> `Pi4J` in accordance with the spelling at https://pi4j.com/ 
* Changed `RaspinLoop` -> `RaspInLoop` in accordance with the project's name
* Changed `java` -> `Java` in accordance with https://docs.oracle.com/en/
* Changed `raspberry` / `raspberry pi` -> `Raspberry`  / `Raspberry Pi` in accordance with https://www.raspberrypi.org/
* Changed `eclipse` -> `Eclipse` in accordance with http://www.eclipse.org/
* Changed `InetlliJ` -> `IntelliJ` in accordance with http://jetbrains.com
* Changed `i2c` -> `I2C` in accordance with https://i2c.info/
* Changed `spi` -> `SPI` in accordance with https://www.intel.com/content/dam/support/us/en/documents/software/chipset-software/327432-004_espi_base_specification_rev1.0.pdf
* Fixed broken link to project repository.